### PR TITLE
Remove bedrock docs

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
   },
   "peerDependencies": {
     "bedrock": "1.x - 3.x",
-    "bedrock-docs": "^3.0.0",
     "bedrock-express": "^2.x - 3.x",
     "bedrock-ledger-context": "^15.0.0",
     "bedrock-ledger-node": "8.x - 10.x",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "peerDependencies": {
     "bedrock": "1.x - 3.x",
-    "bedrock-express": "^2.x - 3.x",
+    "bedrock-express": "2.x - 3.x",
     "bedrock-ledger-context": "^15.0.0",
     "bedrock-ledger-node": "8.x - 10.x",
     "bedrock-mongodb": "7.x - 8.x",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "bedrock-ledger-context": "^15.0.0",
     "bedrock-ledger-node": "8.x - 10.x",
     "bedrock-mongodb": "7.x - 8.x",
-    "bedrock-passport": "3.x - 5.x",
+    "bedrock-passport": "3.x - 6.x",
     "bedrock-permission": "^3.0.0",
     "bedrock-rest": "2.1.0 - 3.x",
     "bedrock-server": "^2.2.0"

--- a/test/package.json
+++ b/test/package.json
@@ -13,7 +13,6 @@
     "axios": "^0.19.2",
     "bedrock": "^3.1.1",
     "bedrock-account": "^4.1.0",
-    "bedrock-docs": "^3.0.0",
     "bedrock-express": "^3.2.0",
     "bedrock-https-agent": "^2.0.0",
     "bedrock-injector": "^1.0.0",


### PR DESCRIPTION
This removes `bedrock-docs` from the peerDeps and test dependencies. it also corrects an invalid semver for `bedrock-express`.

I made a separate PR as removing libraries could introduce concerns about stability in other projects. Test project is running just fine with out `bedrock-docs`, `/lib` does not require it anywhere.